### PR TITLE
Add jackson datatype dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,11 @@
             <artifactId>mysql-connector-java</artifactId>
             <version>8.0.24</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>2.13.4</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
This dependency is needed to enable parsing java types added in DateTime API